### PR TITLE
added the ability to use a :must_not_have config for certain generators.

### DIFF
--- a/lib/pollution/generator.ex
+++ b/lib/pollution/generator.ex
@@ -18,7 +18,7 @@ defmodule Pollution.Generator do
     state
     |> State.update_with_derived_values(locals)
     |> state.type.next_value(locals)
-    |> next_if_must_not_have
+    |> next_if_must_not_have(locals)
   end
 
   def as_stream(state, locals \\ []) do

--- a/lib/pollution/generator.ex
+++ b/lib/pollution/generator.ex
@@ -18,6 +18,7 @@ defmodule Pollution.Generator do
     state
     |> State.update_with_derived_values(locals)
     |> state.type.next_value(locals)
+    |> next_if_must_not_have
   end
 
   def as_stream(state, locals \\ []) do
@@ -33,5 +34,12 @@ defmodule Pollution.Generator do
     other_vals.(state)
   end
 
-end
+  def next_if_must_not_have(original = {value, state = %{must_not_have: must_not_have}}, locals \\ []) do
+    if MapSet.member?(must_not_have, value) do
+      next_value(state, locals)
+    else
+      original
+    end
+  end
 
+end

--- a/lib/pollution/generators/atom.ex
+++ b/lib/pollution/generators/atom.ex
@@ -9,6 +9,7 @@ defmodule Pollution.Generator.Atom do
   @defaults %State{
     type:       __MODULE__,
     must_have:  [],
+    must_not_have: MapSet.new,
     min: 0,                     # atom length
     max: 255,
     extra: %{
@@ -102,5 +103,5 @@ defmodule Pollution.Generator.Atom do
   def shrink_backtrack(sp = %SP{}) do
     %SP{ sp | done: true }
   end
-  
+
 end

--- a/lib/pollution/generators/float.ex
+++ b/lib/pollution/generators/float.ex
@@ -28,6 +28,7 @@ defmodule Pollution.Generator.Float do
   @defaults %State{
     type:      __MODULE__,
     must_have: [ 0.0, -1.0, 1.0, @min, -@min ],
+    must_not_have: MapSet.new,
     min:      -1.0e6,
     max:       1.0e6,
   }
@@ -40,6 +41,7 @@ defmodule Pollution.Generator.Float do
     |> State.add_derived_to_state(options)
     |> State.add_min_max_to_state(options)
     |> State.add_must_have_to_state(options)
+    |> State.add_must_not_have_to_state(options)
     |> update_constraints
   end
 

--- a/lib/pollution/generators/int.ex
+++ b/lib/pollution/generators/int.ex
@@ -9,6 +9,7 @@ defmodule Pollution.Generator.Int do
   @state %State{
     type:       __MODULE__,
     must_have:  [ 0, -1, 1 ],
+    must_not_have: MapSet.new,
     min:      -1_000,
     max:       1_000,
   }
@@ -23,6 +24,7 @@ defmodule Pollution.Generator.Int do
     |> State.add_derived_to_state(options)
     |> State.add_min_max_to_state(options)
     |> State.add_must_have_to_state(options)
+    |> State.add_must_not_have_to_state(options)
     |> update_constraints()
   end
 

--- a/lib/pollution/generators/list.ex
+++ b/lib/pollution/generators/list.ex
@@ -9,6 +9,7 @@ defmodule Pollution.Generator.List do
   @defaults %State{
     type:        __MODULE__,
     must_have:   [],
+    must_not_have: MapSet.new,
     min:         0,    # this is min length
     max:         100,
     child_types: [ Pollution.VG.value(42) ],
@@ -20,19 +21,20 @@ defmodule Pollution.Generator.List do
     @defaults
     |> State.add_min_max_length_to_state(options)
     |> State.add_must_have_to_state(options)
+    |> State.add_must_not_have_to_state(options)
     |> State.add_element_type_to_state(options)
     |> maybe_add_empty_list_to_must_have(options)
   end
 
 
-  
+
   @doc """
   Return a tuple containing the next value for this type, along with a
   potentially updated type state.
-  
+
   If there are elements in the `must_have` list, return the first of them,
   and return a state where that element has been removed from `must_have`.
-  
+
   Otherwise return a random value according to the generator constraints.
   """
   def next_value(state, locals) do

--- a/lib/pollution/generators/map.ex
+++ b/lib/pollution/generators/map.ex
@@ -11,6 +11,7 @@ defmodule Pollution.Generator.Map do
   @defaults %State{
     type:        __MODULE__,
     must_have:   [],
+    must_not_have: MapSet.new,
     min:         0,    # this is min length
     max:         100,
     child_types: nil
@@ -21,19 +22,20 @@ defmodule Pollution.Generator.Map do
     @defaults
     |> State.add_min_max_length_to_state(options)
     |> State.add_must_have_to_state(options)
+    |> State.add_must_not_have_to_state(options)
     |> add_element_types_to_state(options)
     |> maybe_add_empty_map_to_must_have(options)
   end
 
 
-  
+
   @doc """
   Return a tuple containing the next value for this type, along with a
   potentially updated type state.
-  
+
   If there are elements in the `must_have` list, return the first of them,
   and return a state where that element has been removed from `must_have`.
-  
+
   Otherwise return a random value according to the generator constraints.
   """
   def next_value(state, locals) do
@@ -162,4 +164,3 @@ defmodule Pollution.Generator.Map do
   end
 
 end
-

--- a/lib/pollution/generators/string.ex
+++ b/lib/pollution/generators/string.ex
@@ -9,6 +9,7 @@ defmodule Pollution.Generator.String do
   @defaults %State{
     type:       __MODULE__,
     must_have:  [ "", " " ],
+    must_not_have: MapSet.new,
     min: 0,              # string length
     max: 300,
     extra: %{
@@ -22,6 +23,7 @@ defmodule Pollution.Generator.String do
     @defaults
     |> add_character_range_to_state(options)
     |> State.add_min_max_length_to_state(options)
+    |> State.add_must_not_have_to_state(options)
     |> update_constraints
   end
 
@@ -104,7 +106,7 @@ defmodule Pollution.Generator.String do
     end
   end
 
-  
+
   def shrink_one(sp = %SP{low: low, current: current})
   when :erlang.size(current) == low do
     %SP{ sp | done: true }
@@ -113,9 +115,9 @@ defmodule Pollution.Generator.String do
   def shrink_one(sp = %SP{current: << _head :: utf8, rest :: binary >>})  do
     %SP{ sp | current: rest }
   end
-  
+
   def shrink_backtrack(sp = %SP{}) do
     %SP{ sp | done: true }
   end
-  
+
 end

--- a/lib/pollution/generators/tuple.ex
+++ b/lib/pollution/generators/tuple.ex
@@ -9,6 +9,7 @@ defmodule Pollution.Generator.Tuple do
   @defaults %State{
     type:       __MODULE__,
     must_have:  [],
+    must_not_have: MapSet.new,
     child_types: [ VG.seq(of: [VG.value(42)]) ],
     min: 0,                     # tuple length
     max: 6,
@@ -101,7 +102,7 @@ defmodule Pollution.Generator.Tuple do
     with len = length(list),
     do: { VG.list(of: VG.seq(of: list), min: len, max: len), length(list) }
   end
-  
+
   defp update_delegate(state, delegate) do
     %State{state | extra: %{ delegate: delegate }}
   end
@@ -109,5 +110,5 @@ defmodule Pollution.Generator.Tuple do
   defp update_delegate(state, delegate, length) do
     %State{state | extra: %{ delegate: delegate }, min: length, max: length}
   end
-  
+
 end

--- a/lib/pollution/state.ex
+++ b/lib/pollution/state.ex
@@ -3,16 +3,17 @@ defmodule Pollution.State do
   @moduledoc false
 
   defstruct(
-    type:         __MODULE__,
-    last_value:   nil,
-    must_have:    [ ],
-    child_types:  [ ],
-    last_child:   nil,
-    derived:      [ ],
-    min:          nil,
-    max:          nil,
-    distribution: nil,
-    extra:        nil,
+    type:          __MODULE__,
+    last_value:    nil,
+    must_have:     [ ],
+    must_not_have: MapSet.new,
+    child_types:   [ ],
+    last_child:    nil,
+    derived:       [ ],
+    min:           nil,
+    max:           nil,
+    distribution:  nil,
+    extra:         nil,
   )
 
   ##############################
@@ -27,7 +28,7 @@ defmodule Pollution.State do
     state
     |> add_to_state(:derived, options[:derived])
   end
-  
+
   def add_min_max_to_state(state, options) do
     state
     |> add_to_state(:min, options[:min])
@@ -39,16 +40,25 @@ defmodule Pollution.State do
     |> add_to_state(:min, options[:min])
     |> add_to_state(:max, options[:max])
   end
-  
+
   def add_must_have_to_state(state, options) do
     add_to_state(state, :must_have, options[:must_have])
   end
-  
+
   def add_element_type_to_state(state, options) do
     add_to_state(state, :child_types, maybe_wrap_in_list(options[:of]))
   end
-  
-  
+
+  def add_must_not_have_to_state(state, options) do
+    must_not_have =
+      options
+      |> Access.get(:must_not_have)
+      |> into_mapset
+
+    add_to_state(state, :must_not_have, must_not_have)
+  end
+
+
   def add_to_state(state, _keys, nil),  do: state
   def add_to_state(state, key, value) when is_atom(key) do
     Map.put(state, key, value)
@@ -82,10 +92,13 @@ defmodule Pollution.State do
     end)
     Map.put(state, :must_have, updated_must_have)
   end
-  
+
   def maybe_wrap_in_list(nil), do: nil
   def maybe_wrap_in_list(l) when is_list(l), do: l
   def maybe_wrap_in_list(v), do: [v]
+
+  def into_mapset(nil), do: MapSet.new()
+  def into_mapset(v), do: v |> maybe_wrap_in_list |> MapSet.new
 
 end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,2 @@
+%{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}

--- a/test/generators/atom_test.exs
+++ b/test/generators/atom_test.exs
@@ -13,7 +13,7 @@ defmodule Generator.AtomTest do
   end
 
   test "atom() returns atoms" do
-    run_test([], fn a->
+    run_test([], fn a ->
       assert is_atom(a)
     end)
   end
@@ -24,11 +24,17 @@ defmodule Generator.AtomTest do
       do: assert len in 4..8
     end)
   end
-  
+
   test "setting must_have adds items to the stream" do
     atoms = atom(must_have: [ :donald, :mickey ]) |> G.as_stream([]) |> Enum.take(100)
     assert :donald in atoms
     assert :mickey in atoms
+  end
+
+  test "setting must_not_have removes items from the stream" do
+    run_test([min: 1, max: 2, must_not_have: [1]], fn a ->
+      assert(a != 1)
+    end)
   end
 
 end

--- a/test/generators/string_test.exs
+++ b/test/generators/string_test.exs
@@ -46,7 +46,7 @@ defmodule Generator.StringTest do
       |> Enum.each(fn (ch) -> assert ch in ?a..?z end)
     end)
   end
-  
+
   test "string() returns uppercase if requested" do
     run_test([chars: :upper], fn str ->
       assert is_binary(str)
@@ -55,7 +55,7 @@ defmodule Generator.StringTest do
       |> Enum.each(fn (ch) -> assert ch in ?A..?Z end)
     end)
   end
-  
+
   test "string() returns a range if requested" do
     run_test([chars: ?e..?m], fn str ->
       assert is_binary(str)
@@ -71,7 +71,7 @@ defmodule Generator.StringTest do
       assert "" in strings
       assert " " in strings
     end
-  
+
     test "for string(min: 1) returns a space" do
       strings = string(min: 1) |> G.as_stream([]) |> Enum.take(1)
       assert " " in strings
@@ -81,6 +81,21 @@ defmodule Generator.StringTest do
       strings = string(max: 0) |> G.as_stream([]) |> Enum.take(3)
       assert strings == [ "", "", "" ]
     end
-    
+
+    test "superceded by must_not_have, but can overlap" do
+      without_empty = string(must_not_have: [""]) |> G.as_stream([]) |> Enum.take(2)
+      without_space = string(must_not_have: [" "]) |> G.as_stream([]) |> Enum.take(2)
+      without_both = string(must_not_have: ["", " "]) |> G.as_stream([]) |> Enum.take(2)
+
+      refute "" in without_empty
+      assert " " in without_empty
+
+      refute " " in without_space
+      assert "" in without_space
+
+      refute "" in without_both
+      refute " " in without_both
+    end
+
   end
 end


### PR DESCRIPTION
A proposal that will help us with our integration tests.  Normally this could be done simply by adding a `Stream.filter/1` before taking from the generator, but we're building a tool to generate documentation from the same structure that we generate tests, so it would be in our best interest to make these generators as introspectable as possible.  Otherwise we will have to wrap it in our own structures with our own helper functions and the like.