### PR TITLE
shorthand for choosing from a list of static values

### DIFF
--- a/lib/pollution/generators/choose.ex
+++ b/lib/pollution/generators/choose.ex
@@ -12,6 +12,9 @@ defmodule Pollution.Generator.Choose do
     type: __MODULE__
   }
 
+  def create([values: values]) do
+    create(from: Enum.map(values, &G.Value.create(value: &1)))
+  end
   def create(options) when is_list(options) do
     @state
     |> State.set_param(:child_types, Util.list_to_map(options[:from]))

--- a/lib/pollution/vg.ex
+++ b/lib/pollution/vg.ex
@@ -62,6 +62,8 @@ defmodule Pollution.VG do
         iex> import Pollution.{Generator, VG}
         iex> choose(from: [ int(min: 3, max: 7), bool ]) |> as_stream |> Enum.take(5)
         [6, false, 4, true, true]
+        iex> choose(values: [5, 6, 7]) |> as_stream |> Enum.take(5)
+        [6, 5, 5, 7, 6]
   """
   def choose(options), do: Choose.create(options)
 

--- a/test/generators/choose_test.exs
+++ b/test/generators/choose_test.exs
@@ -24,5 +24,17 @@ defmodule ChooseTest do
     end
   end
 
-end
+  test "choosing from values returns on of those values" do
+    result = choose(values: [ 1, 2, 3 ]) |> G.as_stream |> Enum.take(100)
 
+    counts = Enum.reduce(result, %{}, fn v, counts ->
+      Map.update(counts, v, 0, &(&1+1))
+    end)
+
+    with likely_range = 10..50 do
+      assert counts[1] in likely_range
+      assert counts[2] in likely_range
+      assert counts[3] in likely_range
+    end
+  end
+end


### PR DESCRIPTION
I had some tests where I wanted to choose from a static list of values.  It's possible by wrapping them in `value`: this provides a shorthand.