### PR TITLE
Added support for the filters option in the Pollution.VG.int function

### DIFF
--- a/lib/pollution/generators/int.ex
+++ b/lib/pollution/generators/int.ex
@@ -23,6 +23,7 @@ defmodule Pollution.Generator.Int do
     |> State.add_derived_to_state(options)
     |> State.add_min_max_to_state(options)
     |> State.add_must_have_to_state(options)
+    |> State.add_filters_to_state(options)
     |> update_constraints()
   end
 

--- a/lib/pollution/state.ex
+++ b/lib/pollution/state.ex
@@ -44,7 +44,11 @@ defmodule Pollution.State do
   def add_must_have_to_state(state, options) do
     add_to_state(state, :must_have, options[:must_have])
   end
-
+  
+  def add_filters_to_state(state, options) do
+    add_to_state(state, :filters, options[:filters])
+  end
+  
   def add_element_type_to_state(state, options) do
     add_to_state(state, :child_types, maybe_wrap_in_list(options[:of]))
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+%{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}

--- a/test/generators/int_test.exs
+++ b/test/generators/int_test.exs
@@ -124,5 +124,27 @@ defmodule IntTest do
     end
   end
 
+  describe "int value filters" do
+    test "filters out values with the specified predicate" do
+      int(filters: %{negative_numbers: fn n -> (n < 0) end})
+      |> G.as_stream()
+      |> Enum.take(100)
+      |> Enum.each(fn v -> assert v >= 0 end)
+    end
+    
+    test "filters out values by chaining the specified predicates" do
+      int(filters: %{ 
+        negative_numbers: fn n -> (n < 0) end,
+        odd_numbers: fn n -> rem(n, 2) == 0 end
+      }) |> G.as_stream()
+      |> Enum.take(100)
+      |> Enum.each(fn v -> assert((v >= 0) and (rem(v, 2) != 0))  end)
+    end
+    
+    test "causes error when non-predicate is provided" do
+      assert catch_error(int(min: 1, filters: %{bogus: 2149}) |> G.as_stream() |> Enum.take(1)) == {:badfun, 2149}
+    end
+  end
+
 end
 


### PR DESCRIPTION
This pull request can be considered a proof of concept for the proposal available on [issue #11](https://github.com/pragdave/pollution/issues/11)

Support for the `filters` option as been added for the `Pollution.VG.int` function.
The filters options allows to specify a map of predicates:
    filters: %{negative_number: fn n -> ... end}
Values matching one of the predicates in the map are discarded.

Feedback most welcome.