### PR TITLE
don't shrink lists past where they fail

### DIFF
--- a/lib/pollution/generators/list.ex
+++ b/lib/pollution/generators/list.ex
@@ -48,10 +48,10 @@ defmodule Pollution.Generator.List do
   # Shrinking stuff #
   ###################
 
-  def params_for_shrink(%{ min: min, max: max }, current) do
+  def params_for_shrink(%{ min: min }, current) do
     %SP{
       low:       min,   # lengths
-      high:      max,
+      high:      current, # last failing value
       current:   current,
       shrink:    &shrink_one/1,
       backtrack: &shrink_backtrack/1
@@ -63,12 +63,12 @@ defmodule Pollution.Generator.List do
     %SP{ sp | done: true }
   end
 
-  def shrink_one(sp = %SP{current: [ _head | tail ]})  do
-    %SP{ sp | current: tail }
+  def shrink_one(sp = %SP{current: [ _head | tail ] = current})  do
+    %SP{ sp | current: tail, high: current }
   end
 
-  def shrink_backtrack(sp = %SP{}) do
-    %SP{ sp | done: true }
+  def shrink_backtrack(sp = %SP{high: high}) do
+    %SP{ sp | current: high, done: true }
   end
 
 

--- a/test/shrinker/list_test.exs
+++ b/test/shrinker/list_test.exs
@@ -17,7 +17,7 @@ defmodule Shrinker.ListTest do
       assert_passes = fn (_) ->
         flunk "shouldn't call the code"
       end
-    
+
       assert do_shrink(assert_passes, [], min: 0, max: 0) == []
     end
 
@@ -25,10 +25,10 @@ defmodule Shrinker.ListTest do
       assert_passes = fn (_) ->
         flunk "shouldn't call the code"
       end
-    
+
       assert do_shrink(assert_passes, [1,2,3], min: 3, max: 3) == [1,2,3]
     end
-    
+
     test "reduces the length of a list to zero if appropriate" do
       assert_passes = fn (_) ->
         false
@@ -38,10 +38,16 @@ defmodule Shrinker.ListTest do
 
     test "reduces the length until a test passes" do
       assert_passes = fn (%{wibble: val}) ->
-        length(val) <= 2
+        length(val) <= 1
       end
       assert do_shrink(assert_passes, [1,2,3,4], min: 0) == [3,4]
     end
 
+    test "stops immediately if the first shrink passes" do
+      assert_passes = fn (_) ->
+        true
+      end
+      assert do_shrink(assert_passes, [1,2,3,4], min: 0) == [1,2,3,4]
+    end
   end
 end


### PR DESCRIPTION
There are other changes I'd like to make before merging (maps probably have the same problem, maybe tuples too), but I wanted to run this by you before going down this road.

Our test suite had a function which failed with a non-empty list, but succeeded with an empty list.  The shrinking behavior would shrink down to the empty list, "backtrack", and tell us that the empty list failed.  I ended up tracking down the bug by logging the values the shrinker was trying.

What's happening is that the backtracking fails to go back to a failing value. Instead, it stays at the first passing value.  There's a test for the behavior, but I believe that the test is wrong in this case.

Since the `VG.List` shrinker isn't using `high`, I re-use it to store the last failed value.