### PR TITLE
Use byte_size guard instead of :erlang.size

### DIFF
--- a/lib/pollution/generators/string.ex
+++ b/lib/pollution/generators/string.ex
@@ -114,7 +114,7 @@ defmodule Pollution.Generator.String do
 
 
   def shrink_one(sp = %SP{low: low, current: current})
-  when :erlang.size(current) == low do
+  when byte_size(current) == low do
     %SP{ sp | done: true }
   end
 


### PR DESCRIPTION
`:erlang.size/1` does not work with elixir 1.10. This fixes the compile error.

Addresses #15 